### PR TITLE
Fix #38 - Specify actual path to Version.hpp instead of picking up Version.hpp.in

### DIFF
--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -148,7 +148,7 @@ set(kiva_src Aggregator.cpp
              Instance.hpp
              Mesher.cpp
              Mesher.hpp
-             Version.hpp )
+             "${PROJECT_BINARY_DIR}/Version.hpp" )
 
 include_directories("${kiva_BINARY_DIR}/src/libkiva")
 


### PR DESCRIPTION
Fix #38 - Specify actual path to Version.hpp instead of picking up Version.hpp.in