### PR TITLE
Remove unnecessarily included headers.

### DIFF
--- a/src/kiva/Simulator.hpp
+++ b/src/kiva/Simulator.hpp
@@ -6,12 +6,7 @@
 
 #include <iostream>
 
-#include <mgl2/mgl.h>
-
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-
-#include <boost/lexical_cast.hpp>
 
 #include "BoundaryConditions.hpp"
 #include "Geometry.hpp"

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -180,7 +180,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_features(libkiva PUBLIC cxx_std_17)
+target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)
 generate_export_header(libkiva)


### PR DESCRIPTION
This removes unnecessary include headers in Kiva.