### PR TITLE
Add clockwise check for polygon

### DIFF
--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -133,7 +133,8 @@ void Foundation::createMeshData() {
   }
 
   if (!isCounterClockWise(polygon)) {
-      boost::geometry::correct(polygon);
+    boost::geometry::correct(polygon);
+    showMessage(MSG_WARN, "Foundation floor polygon was modified to be counterclockwise as required in Kiva.");
   }
 
   Material air;

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -132,6 +132,10 @@ void Foundation::createMeshData() {
     buildingSurfaces.push_back(poly);
   }
 
+  if (!isCounterClockWise(polygon)) {
+      boost::geometry::correct(polygon);
+  }
+
   Material air;
   air.conductivity = 0.02587;
   air.density = 1.275;

--- a/src/libkiva/Geometry.cpp
+++ b/src/libkiva/Geometry.cpp
@@ -11,6 +11,14 @@ namespace Kiva {
 
 static const double PI = 4.0 * atan(1.0);
 
+bool isCounterClockWise(Polygon poly) {
+  double area = boost::geometry::area(poly);
+  if (area < 0) {
+    return false;
+  }
+  return true;
+}
+
 bool isRectilinear(Polygon poly) {
   for (std::size_t v = 0; v < poly.outer().size(); v++) {
     double x = poly.outer()[v].get<0>();

--- a/src/libkiva/Geometry.hpp
+++ b/src/libkiva/Geometry.hpp
@@ -40,6 +40,7 @@ MultiPolygon mirrorY(MultiPolygon poly, double y);
 Polygon symmetricUnit(Polygon poly);
 bool isXSymmetric(Polygon poly);
 bool isYSymmetric(Polygon poly);
+bool isCounterClockWise(Polygon poly);
 double getXmin(Polygon poly, std::size_t vertex);
 double getYmin(Polygon poly, std::size_t vertex);
 double getXmax(Polygon poly, std::size_t vertex);

--- a/test/unit/foundation.unit.cpp
+++ b/test/unit/foundation.unit.cpp
@@ -1,9 +1,9 @@
 /* Copyright (c) 2012-2021 Big Ladder Software LLC. All rights reserved.
  * See the LICENSE file for additional terms and conditions. */
 
+#include "fixtures/foundation-fixture.hpp"
 #include "fixtures/aggregator-fixture.hpp"
 #include "fixtures/bestest-fixture.hpp"
-#include "fixtures/foundation-fixture.hpp"
 #include "fixtures/typical-fixture.hpp"
 
 #include "Errors.hpp"
@@ -343,7 +343,9 @@ TEST_F(FoundationFixture, clockwiseSurface) {
   fnd.polygon.outer().push_back(Point(6.0, -6.0));
   fnd.polygon.outer().push_back(Point(6.0, 6.0));
   fnd.polygon.outer().push_back(Point(-6.0, 6.0));
+  EXPECT_FALSE(isCounterClockWise(fnd.polygon));
   fnd.createMeshData();
+  EXPECT_TRUE(isCounterClockWise(fnd.polygon));
 }
 
 // Google Test main

--- a/test/unit/foundation.unit.cpp
+++ b/test/unit/foundation.unit.cpp
@@ -1,9 +1,9 @@
 /* Copyright (c) 2012-2021 Big Ladder Software LLC. All rights reserved.
  * See the LICENSE file for additional terms and conditions. */
 
-#include "fixtures/foundation-fixture.hpp"
 #include "fixtures/aggregator-fixture.hpp"
 #include "fixtures/bestest-fixture.hpp"
+#include "fixtures/foundation-fixture.hpp"
 #include "fixtures/typical-fixture.hpp"
 
 #include "Errors.hpp"
@@ -261,7 +261,6 @@ TEST_F(AggregatorFixture, validation) {
   EXPECT_DEATH(floor_results.calc_weighted_results(),
                "Aggregation requested for surface that is not part of foundation instance.");
 
-
   floor_results = Aggregator(Surface::SurfaceType::ST_SLAB_CORE);
 
   floor_results.add_instance(instances[0].ground.get(), 0.25);
@@ -285,50 +284,67 @@ TEST_F(TypicalFixture, convectionCallback) {
   double hc2 = bcs.slabConvectionAlgorithm(290., 295., 0., 0., 0.);
   EXPECT_NE(hc1, hc2);
   EXPECT_EQ(2.0, hc2);
-  bcs.slabConvectionAlgorithm = [=](double Tsurf, double Tamb, double HfTerm, double roughness, double cosTilt) -> double {
-      double deltaT = Tsurf - Tamb;
-      return hc2 + deltaT*deltaT + hc1 - getDOE2ConvectionCoeff(Tsurf, Tamb, HfTerm, roughness, cosTilt);
+  bcs.slabConvectionAlgorithm = [=](double Tsurf, double Tamb, double HfTerm, double roughness,
+                                    double cosTilt) -> double {
+    double deltaT = Tsurf - Tamb;
+    return hc2 + deltaT * deltaT + hc1 -
+           getDOE2ConvectionCoeff(Tsurf, Tamb, HfTerm, roughness, cosTilt);
   };
   double hc3 = bcs.slabConvectionAlgorithm(290., 295., 0., 0., 0.);
 
   EXPECT_NEAR(hc3, 27.0, 0.00001);
-
 }
 
 TEST_F(FoundationFixture, foundationSurfaces) {
-    fnd.foundationDepth = 1.0;
-    fnd.wall.heightAboveGrade = 0.0;
-    Material insulation(0.0288, 28.0, 1450.0);
-    InputBlock extIns;
-    extIns.z = 0;
-    extIns.x = fnd.wall.totalWidth();
-    extIns.depth = 1.0;
-    extIns.width = 0.05;
-    extIns.material = insulation;
-    fnd.inputBlocks.push_back(extIns);
-    fnd.createMeshData();
-    Domain domain(fnd);
-    EXPECT_EQ(fnd.surfaces[6].type, Surface::ST_GRADE);
-    EXPECT_EQ(fnd.surfaces[8].type, Surface::ST_WALL_TOP);
-    EXPECT_NEAR(fnd.surfaces[8].xMax, fnd.surfaces[6].xMin, 0.00001);
+  fnd.foundationDepth = 1.0;
+  fnd.wall.heightAboveGrade = 0.0;
+  Material insulation(0.0288, 28.0, 1450.0);
+  InputBlock extIns;
+  extIns.z = 0;
+  extIns.x = fnd.wall.totalWidth();
+  extIns.depth = 1.0;
+  extIns.width = 0.05;
+  extIns.material = insulation;
+  fnd.inputBlocks.push_back(extIns);
+  fnd.createMeshData();
+  Domain domain(fnd);
+  EXPECT_EQ(fnd.surfaces[6].type, Surface::ST_GRADE);
+  EXPECT_EQ(fnd.surfaces[8].type, Surface::ST_WALL_TOP);
+  EXPECT_NEAR(fnd.surfaces[8].xMax, fnd.surfaces[6].xMin, 0.00001);
 }
 
 TEST_F(FoundationFixture, foundationSurfaces2) {
-    Material insulation(0.0288, 28.0, 1450.0);
-    InputBlock intIns;
-    intIns.z = 0.0;
-    intIns.x = 0.0;
-    intIns.depth = 1.0;
-    intIns.width = -0.05;
-    intIns.material = insulation;
-    fnd.inputBlocks.push_back(intIns);
-    fnd.createMeshData();
-    Domain domain(fnd);
-    EXPECT_EQ(fnd.surfaces[5].type, Surface::ST_SLAB_CORE);
-    EXPECT_EQ(fnd.surfaces[8].type, Surface::ST_WALL_TOP);
-    EXPECT_NEAR(fnd.surfaces[5].xMax, fnd.surfaces[8].xMin, 0.00001);
+  Material insulation(0.0288, 28.0, 1450.0);
+  InputBlock intIns;
+  intIns.z = 0.0;
+  intIns.x = 0.0;
+  intIns.depth = 1.0;
+  intIns.width = -0.05;
+  intIns.material = insulation;
+  fnd.inputBlocks.push_back(intIns);
+  fnd.createMeshData();
+  Domain domain(fnd);
+  EXPECT_EQ(fnd.surfaces[5].type, Surface::ST_SLAB_CORE);
+  EXPECT_EQ(fnd.surfaces[8].type, Surface::ST_WALL_TOP);
+  EXPECT_NEAR(fnd.surfaces[5].xMax, fnd.surfaces[8].xMin, 0.00001);
 }
 
+TEST_F(FoundationFixture, clockwiseSurface) {
+  Material insulation(0.0288, 28.0, 1450.0);
+  InputBlock intIns;
+  intIns.z = 0.0;
+  intIns.x = 0.0;
+  intIns.depth = 1.0;
+  intIns.width = -0.05;
+  intIns.material = insulation;
+  fnd.inputBlocks.push_back(intIns);
+  fnd.polygon.clear();
+  fnd.polygon.outer().push_back(Point(-6.0, -6.0));
+  fnd.polygon.outer().push_back(Point(6.0, -6.0));
+  fnd.polygon.outer().push_back(Point(6.0, 6.0));
+  fnd.polygon.outer().push_back(Point(-6.0, 6.0));
+  fnd.createMeshData();
+}
 
 // Google Test main
 int main(int argc, char **argv) {


### PR DESCRIPTION
This pull request creates a bool function checking whether the polygon is counterclockwise, otherwise it is modified to satisfy this requirement.  A unit test was added for this condition.  The document also reformatted for clang.