### PR TITLE
Fix w4 warnings

### DIFF
--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -11,10 +11,17 @@ set(kiva_src Main.cpp
 set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
-target_compile_options(libkiva PUBLIC -Wall)
+
 target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
+
+if (MSVC)
+  # Remove "potential loss of data" warning in Boost
+  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
+endif()
+
+target_compile_options(kiva PUBLIC -W4)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -11,7 +11,7 @@ set(kiva_src Main.cpp
 set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
-
+target_compile_options(libkiva PUBLIC /W4)
 target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MSVC)
   set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
 endif()
 
-target_compile_options(kiva PUBLIC -W4)
+target_compile_options(kiva PUBLIC -w4)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -22,7 +22,7 @@ set(kiva_suppress_warnings Main.cpp
                            Simulator.cpp)
 if (MSVC)
   set_source_files_properties(${kiva_suppress_warnings} PROPERTIES COMPILE_FLAGS /wd4458)
-elseif (IOS)
+elseif (APPLE)
   set_source_files_properties(${kiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 elseif (UNIX)
   # unknown-pragmas comes from using pragma omp parallel. It is a knonw issue. Possible solution will be to add '-fopenmp'

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -16,10 +16,17 @@ target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 
+set(kiva_suppress_warnings Main.cpp
+                           Input.cpp
+                           InputParser.cpp
+                           Simulator.cpp)
 if (MSVC)
-  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
-else()
-  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+  set_source_files_properties(${kiva_suppress_warnings} PROPERTIES COMPILE_FLAGS /wd4458)
+elseif (IOS)
+  set_source_files_properties(${kiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+elseif (UNIX)
+  # unknown-pragmas comes from using pragma omp parallel. It is a knonw issue. Possible solution will be to add '-fopenmp'
+  set_source_files_properties(${kiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-misleading-indentation -Wno-unknown-pragmas")
 endif()
 
 target_compile_options(kiva PRIVATE

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -17,13 +17,14 @@ target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 
 if (MSVC)
-  # Remove "potential loss of data" warning in Boost
   set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
+else()
+  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 endif()
 
 target_compile_options(kiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
 )
 
 if (KIVA_COVERAGE)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MSVC)
   set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
 endif()
 
-target_compile_options(kiva PUBLIC -Wall)
+target_compile_options(kiva PUBLIC -W4)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -11,7 +11,7 @@ set(kiva_src Main.cpp
 set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
-target_compile_options(libkiva PUBLIC /W4)
+target_compile_options(libkiva PUBLIC -Wall)
 target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MSVC)
   set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
 endif()
 
-target_compile_options(kiva PUBLIC -W4)
+target_compile_options(kiva PUBLIC -Wall)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -30,8 +30,9 @@ elseif (UNIX)
 endif()
 
 target_compile_options(kiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>    # Eventually add /WX
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: # Checks for GCC and Clang
+  -Wall -Wextra -Wpedantic>         # Eventually add -Werror
 )
 
 if (KIVA_COVERAGE)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -21,7 +21,10 @@ if (MSVC)
   set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS /wd4458)
 endif()
 
-target_compile_options(kiva PUBLIC -w4)
+target_compile_options(kiva PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -9,6 +9,13 @@ target_link_libraries(groundplot fmt mgl-static libkiva)
 
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 
+if (MSVC)
+  # Remove "potential loss of data" warning in Boost
+  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
+endif()
+
+target_compile_options(groundplot PUBLIC -W4)
+
 if (KIVA_COVERAGE)
   add_coverage(groundplot)
 endif()

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${
 
 if (MSVC)
   set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
-elseif (IOS)
+elseif (APPLE)
   set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 elseif (UNIX)
   # unknown-pragmas comes from using pragma omp parallel. It is a knonw issue. Possible solution will be to add '-fopenmp'

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -1,9 +1,9 @@
 project(groundplot)
 
-set(kiva_src GroundPlot.cpp
-             GroundPlot.hpp )
+set(groundplot_src  GroundPlot.cpp
+                    GroundPlot.hpp )
 
-add_library(groundplot STATIC ${kiva_src})
+add_library(groundplot STATIC ${groundplot_src})
 
 target_link_libraries(groundplot fmt mgl-static libkiva)
 
@@ -11,7 +11,7 @@ target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${
 
 if (MSVC)
   # Remove "potential loss of data" warning in Boost
-  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
+  set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
 endif()
 
 target_compile_options(groundplot PUBLIC -W4)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -14,7 +14,7 @@ if (MSVC)
   set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
 endif()
 
-target_compile_options(groundplot PUBLIC -Wall)
+target_compile_options(groundplot PUBLIC -W4)
 
 if (KIVA_COVERAGE)
   add_coverage(groundplot)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -19,8 +19,9 @@ elseif (UNIX)
 endif()
 
 target_compile_options(groundplot PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>    # Eventually add /WX
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: # Checks for GCC and Clang
+  -Wall -Wextra -Wpedantic>         # Eventually add -Werror
 )
 
 if (KIVA_COVERAGE)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -14,7 +14,7 @@ if (MSVC)
   set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
 endif()
 
-target_compile_options(groundplot PUBLIC -W4)
+target_compile_options(groundplot PUBLIC -Wall)
 
 if (KIVA_COVERAGE)
   add_coverage(groundplot)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -15,7 +15,7 @@ elseif (IOS)
   set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 elseif (UNIX)
   # unknown-pragmas comes from using pragma omp parallel. It is a knonw issue. Possible solution will be to add '-fopenmp'
-  set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-misleading-indentation -Wno-unknown-pragmas")
+  set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-misleading-indentation -Wno-maybe-uninitialized -Wno-unknown-pragmas")
 endif()
 
 target_compile_options(groundplot PRIVATE

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -14,7 +14,11 @@ if (MSVC)
   set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
 endif()
 
-target_compile_options(groundplot PUBLIC -w4)
+#target_compile_options(groundplot PUBLIC -w4)
+target_compile_options(groundplot PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+)
 
 if (KIVA_COVERAGE)
   add_coverage(groundplot)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -10,14 +10,14 @@ target_link_libraries(groundplot fmt mgl-static libkiva)
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 
 if (MSVC)
-  # Remove "potential loss of data" warning in Boost
   set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
+else()
+  set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 endif()
 
-#target_compile_options(groundplot PUBLIC -w4)
 target_compile_options(groundplot PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
 )
 
 if (KIVA_COVERAGE)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -10,9 +10,12 @@ target_link_libraries(groundplot fmt mgl-static libkiva)
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 
 if (MSVC)
-  set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
-else()
-  set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+  set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
+elseif (IOS)
+  set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+elseif (UNIX)
+  # unknown-pragmas comes from using pragma omp parallel. It is a knonw issue. Possible solution will be to add '-fopenmp'
+  set_source_files_properties(GroundPlot.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-misleading-indentation -Wno-unknown-pragmas")
 endif()
 
 target_compile_options(groundplot PRIVATE

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -14,7 +14,7 @@ if (MSVC)
   set_source_files_properties(${groundplot_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4702")
 endif()
 
-target_compile_options(groundplot PUBLIC -W4)
+target_compile_options(groundplot PUBLIC -w4)
 
 if (KIVA_COVERAGE)
   add_coverage(groundplot)

--- a/src/libkiva/Aggregator.cpp
+++ b/src/libkiva/Aggregator.cpp
@@ -58,7 +58,7 @@ void Aggregator::calc_weighted_results() {
     validate();
   }
   results.reset();
-  double Tz{NULL}, Tr{NULL};
+  double Tz{-1}, Tr{-1};
   for (auto &instance : instances) {
     Ground *grnd = instance.first;
     Tz = surface_type == Surface::ST_WALL_INT ? grnd->bcs.wallConvectiveTemp

--- a/src/libkiva/Aggregator.cpp
+++ b/src/libkiva/Aggregator.cpp
@@ -58,7 +58,7 @@ void Aggregator::calc_weighted_results() {
     validate();
   }
   results.reset();
-  double Tz, Tr;
+  double Tz{NULL}, Tr{NULL};
   for (auto &instance : instances) {
     Ground *grnd = instance.first;
     Tz = surface_type == Surface::ST_WALL_INT ? grnd->bcs.wallConvectiveTemp

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -184,7 +184,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PRIVATE /W4)
+target_compile_options(libkiva PUBLIC /W4)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -156,10 +156,9 @@ set(libkiva_src Aggregator.cpp
 option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 
 if (MSVC)
-  # Remove "potential loss of data" warning in Boost
   set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
 else()
-  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder-ctor")
 endif()
 
 if (KIVA_STATIC_LIB)
@@ -186,10 +185,9 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-#target_compile_options(libkiva PUBLIC -w4)
 target_compile_options(libkiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
 )
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -158,6 +158,8 @@ option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 if (MSVC)
   # Remove "potential loss of data" warning in Boost
   set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
+else()
+  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 endif()
 
 if (KIVA_STATIC_LIB)
@@ -184,7 +186,11 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PUBLIC -w4)
+#target_compile_options(libkiva PUBLIC -w4)
+target_compile_options(libkiva PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -184,6 +184,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
+target_compile_options(libkiva PRIVATE /W4)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -155,10 +155,16 @@ set(libkiva_src Aggregator.cpp
 
 option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 
+set(libkiva_suppress_warnings Geometry.cpp
+                              Ground.cpp
+                              Foundation.cpp)
+
 if (MSVC)
-  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
-else()
-  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder-ctor")
+  set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459 /wd6011 /wd6386 ")
+elseif (IOS)
+  set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder-ctor")
+elseif (UNIX)
+  set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder")
 endif()
 
 if (KIVA_STATIC_LIB)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -127,7 +127,7 @@ configure_file (
     "${PROJECT_BINARY_DIR}/Version.hpp"
 )
 
-set(kiva_src Aggregator.cpp
+set(libkiva_src Aggregator.cpp
              Aggregator.hpp
              Algorithms.cpp
              Algorithms.hpp
@@ -157,18 +157,18 @@ option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 
 if (MSVC)
   # Remove "potential loss of data" warning in Boost
-  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
+  set_source_files_properties(${libkiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
 endif()
 
 if (KIVA_STATIC_LIB)
-  add_library(libkiva STATIC ${kiva_src})
+  add_library(libkiva STATIC ${libkiva_src})
   target_compile_definitions(libkiva PRIVATE LIBKIVA_STATIC_DEFINE)
   if(UNIX)
     target_compile_options(libkiva PUBLIC -fPIC)
   endif()
 else()
   set(CMAKE_MACOSX_RPATH 1)
-  add_library(libkiva SHARED ${kiva_src})
+  add_library(libkiva SHARED ${libkiva_src})
   if(KIVA_EXE_BUILD)
     install(TARGETS libkiva DESTINATION bin/)
   endif()

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -157,11 +157,15 @@ option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 
 set(libkiva_suppress_warnings Geometry.cpp
                               Ground.cpp
-                              Foundation.cpp)
+                              Foundation.cpp
+                              Aggregator.cpp
+                              Cell.cpp
+                              Domain.cpp
+                              Instance.cpp)
 
 if (MSVC)
   set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459 /wd6011 /wd6386 ")
-elseif (IOS)
+elseif (APPLE)
   set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder-ctor")
 elseif (UNIX)
   set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder")

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -184,7 +184,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PUBLIC /W4)
+target_compile_options(libkiva PUBLIC -Wall)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -184,7 +184,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PUBLIC -W4)
+target_compile_options(libkiva PUBLIC -w4)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -192,8 +192,9 @@ target_include_directories(libkiva PUBLIC
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
 target_compile_options(libkiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>                              # Eventually add /WX
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>  # Eventually add -Werror
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>    # Eventually add /WX
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: # Checks for GCC and Clang
+  -Wall -Wextra -Wpedantic>         # Eventually add -Werror
 )
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -164,7 +164,7 @@ if (MSVC)
 elseif (IOS)
   set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder-ctor")
 elseif (UNIX)
-  set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder")
+  set_source_files_properties(${libkiva_suppress_warnings} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-reorder -Wno-maybe-uninitialized -Wno-unknown-pragmas")
 endif()
 
 if (KIVA_STATIC_LIB)

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -157,7 +157,7 @@ option( KIVA_STATIC_LIB "Make libkiva a static library" ON )
 
 if (MSVC)
   # Remove "potential loss of data" warning in Boost
-  set_source_files_properties(Geometry.cpp PROPERTIES COMPILE_FLAGS /wd4244)
+  set_source_files_properties(${kiva_src} PROPERTIES COMPILE_FLAGS "/wd4100 /wd4244 /wd4702 /wd4127 /wd4459")
 endif()
 
 if (KIVA_STATIC_LIB)
@@ -184,7 +184,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PUBLIC -Wall)
+target_compile_options(libkiva PUBLIC -W4)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1413,11 +1413,11 @@ void Foundation::createMeshData() {
     Box boundingBox;
     boost::geometry::envelope(polygon, boundingBox);
 
-    double xMinBB = boundingBox.min_corner().get<0>();
-    double yMinBB = boundingBox.min_corner().get<1>();
+    xMinBB = boundingBox.min_corner().get<0>();
+    yMinBB = boundingBox.min_corner().get<1>();
 
-    double xMaxBB = boundingBox.max_corner().get<0>();
-    double yMaxBB = boundingBox.max_corner().get<1>();
+    xMaxBB = boundingBox.max_corner().get<0>();
+    yMaxBB = boundingBox.max_corner().get<1>();
 
     xMin = xMinBB - farFieldWidth;
     yMin = yMinBB - farFieldWidth;

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -105,13 +105,12 @@ Foundation::Foundation()
       deepGroundBoundary(DGB_ZERO_FLUX), wallTopBoundary(WTB_ZERO_FLUX),
       soil(Material(1.73, 1842, 419)), grade(SurfaceProperties(0.9, 0.9, 0.03)),
       coordinateSystem(CS_CARTESIAN), numberOfDimensions(2), useSymmetry(true),
-      reductionStrategy(RS_BOUNDARY), exposedFraction(1.0), useDetailedExposedPerimeter(false),
-      buildingHeight(0.0), hasWall(true), hasSlab(true), perimeterSurfaceWidth(0.0),
-      hasPerimeterSurface(false), isXSymm{false}, mesh(Mesh()), numericalScheme(NS_ADI),
-      linearAreaMultiplier{0}, isYSymm{false}, fADI(0.00001), tolerance(1.0e-6),
-      maxIterations(100000), netArea{0}, reductionLength1{0},
-      wallTopInteriorTemperature{0}, wallTopExteriorTemperature{0}, netPerimeter{0},
-      twoParameters{false}, reductionLength2{0} {}
+      reductionStrategy(RS_BOUNDARY), isXSymm{false}, exposedFraction(1.0), useDetailedExposedPerimeter(false),
+      buildingHeight(0.0), hasWall(true), wallTopInteriorTemperature{0}, wallTopExteriorTemperature{0},
+      twoParameters{false}, reductionLength1{0}, reductionLength2{0},
+      linearAreaMultiplier{0}, isYSymm{false}, hasSlab(true), perimeterSurfaceWidth(0.0),
+      hasPerimeterSurface(false), mesh(Mesh()), numericalScheme(NS_ADI),
+      fADI(0.00001), tolerance(1.0e-6), maxIterations(100000), netArea{0}, netPerimeter{0} {}
 
 void Foundation::createMeshData() {
   std::size_t nV = polygon.outer().size();

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -107,11 +107,11 @@ Foundation::Foundation()
       coordinateSystem(CS_CARTESIAN), numberOfDimensions(2), useSymmetry(true),
       reductionStrategy(RS_BOUNDARY), exposedFraction(1.0), useDetailedExposedPerimeter(false),
       buildingHeight(0.0), hasWall(true), hasSlab(true), perimeterSurfaceWidth(0.0),
-      hasPerimeterSurface(false), mesh(Mesh()), numericalScheme(NS_ADI), fADI(0.00001),
-      tolerance(1.0e-6), maxIterations(100000), isXSymm{false}, isYSymm{false},
-      linearAreaMultiplier{0}, netArea{0}, netPerimeter{0}, reductionLength1{0},
-      reductionLength2{0}, twoParameters{false},
-      wallTopExteriorTemperature{0}, wallTopInteriorTemperature{0} {}
+      hasPerimeterSurface(false), isXSymm{false}, mesh(Mesh()), numericalScheme(NS_ADI),
+      linearAreaMultiplier{0}, isYSymm{false}, fADI(0.00001), tolerance(1.0e-6),
+      maxIterations(100000), netArea{0}, reductionLength1{0},
+      wallTopInteriorTemperature{0}, wallTopExteriorTemperature{0}, netPerimeter{0},
+      twoParameters{false}, reductionLength2{0} {}
 
 void Foundation::createMeshData() {
   std::size_t nV = polygon.outer().size();

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -106,7 +106,10 @@ Foundation::Foundation()
       reductionStrategy(RS_BOUNDARY), exposedFraction(1.0), useDetailedExposedPerimeter(false),
       buildingHeight(0.0), hasWall(true), hasSlab(true), perimeterSurfaceWidth(0.0),
       hasPerimeterSurface(false), mesh(Mesh()), numericalScheme(NS_ADI), fADI(0.00001),
-      tolerance(1.0e-6), maxIterations(100000) {}
+      tolerance(1.0e-6), maxIterations(100000), isXSymm{false}, isYSymm{false},
+      linearAreaMultiplier{0}, netArea{0}, netPerimeter{0}, reductionLength1{0},
+      reductionLength2{0}, twoParameters{false},
+      wallTopExteriorTemperature{0}, wallTopInteriorTemperature{0} {}
 
 void Foundation::createMeshData() {
   std::size_t nV = polygon.outer().size();

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1328,19 +1328,22 @@ void Foundation::createMeshData() {
 
     // General blocks
     for (auto &b : inputBlocks) {
-      Block block;
-      block.material = b.material;
-      block.blockType = Block::SOLID;
-      block.xMin = xRef2 + b.box.min_corner().get<0>();
-      block.xMax = xRef2 + b.box.max_corner().get<0>();
-      block.yMin = 0.0;
-      block.yMax = 1.0;
-      block.setSquarePolygon();
-      block.zMin = b.box.min_corner().get<1>();
-      block.zMax = b.box.max_corner().get<1>();
-      blocks.push_back(block);
+      {
+        Block block;
+        block.material = b.material;
+        block.blockType = Block::SOLID;
+        block.xMin = xRef2 + b.box.min_corner().get<0>();
+        block.xMax = xRef2 + b.box.max_corner().get<0>();
+        block.yMin = 0.0;
+        block.yMax = 1.0;
+        block.setSquarePolygon();
+        block.zMin = b.box.min_corner().get<1>();
+        block.zMax = b.box.max_corner().get<1>();
+        blocks.push_back(block);
+      }
 
       if (twoParameters) {
+        Block block;
         block.material = b.material;
         block.blockType = Block::SOLID;
         block.xMin = xRef1 - b.box.min_corner().get<0>();

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1111,9 +1111,6 @@ void Foundation::createMeshData() {
         }
 
         if (twoParameters) {
-          double &Tin = wallTopInteriorTemperature;
-          double &Tout = wallTopExteriorTemperature;
-          double Tdiff = (Tin - Tout);
           std::size_t N = (std::size_t)((xyWallTopExterior - xyWallTopInterior + DBL_EPSILON) / mesh.minCellDim);
           double temperature = Tin - (1.0 / N) / 2 * Tdiff;
 

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1289,7 +1289,7 @@ void Foundation::createMeshData() {
         double xPosition = xRef2;
 
         // Foundation Wall
-        for (std::size_t n = wall.layers.size() - 1; n < wall.layers.size() /* && n >= 0 */; n--) {
+        for (int n = static_cast<int>(wall.layers.size()) - 1; n >= 0; n--) {
           Block block;
           block.material = wall.layers[n].material;
           block.blockType = Block::SOLID;
@@ -1309,7 +1309,7 @@ void Foundation::createMeshData() {
         double xPosition = xRef1;
 
         // Foundation Wall
-        for (std::size_t n = wall.layers.size() - 1; n < wall.layers.size() /* && n >= 0 */; n--) {
+        for (int n = static_cast<int>(wall.layers.size()) - 1; n >= 0; n--) {
           Block block;
           block.material = wall.layers[n].material;
           block.blockType = Block::SOLID;
@@ -1820,7 +1820,7 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (std::size_t n = wall.layers.size() - 1; n < wall.layers.size() /*>= 0*/; n--) {
+      for (int n = static_cast<int>(wall.layers.size() - 1); n >= 0; n--) {
         Polygon poly;
         poly = offset(polygon, xyPosition + wall.layers[n].thickness);
 
@@ -2398,7 +2398,7 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (std::size_t n = wall.layers.size() - 1; n < wall.layers.size() /*>= 0*/; n--) {
+      for (int n = static_cast<int>(wall.layers.size() - 1); n >= 0; n--) {
         Polygon tempPoly;
         tempPoly = offset(polygon, xyPosition + wall.layers[n].thickness);
 

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1111,8 +1111,8 @@ void Foundation::createMeshData() {
         }
 
         if (twoParameters) {
-          std::size_t N = (std::size_t)((xyWallTopExterior - xyWallTopInterior + DBL_EPSILON) / mesh.minCellDim);
-          double temperature = Tin - (1.0 / N) / 2 * Tdiff;
+          N = (std::size_t)((xyWallTopExterior - xyWallTopInterior + DBL_EPSILON) / mesh.minCellDim);
+          temperature = Tin - (1.0 / N) / 2 * Tdiff;
 
           for (std::size_t n = 1; n <= N; n++) {
             Surface surface;
@@ -2035,11 +2035,11 @@ void Foundation::createMeshData() {
     Box boundingBox;
     boost::geometry::envelope(symmetricPoly, boundingBox);
 
-    double xMinBB = boundingBox.min_corner().get<0>();
-    double yMinBB = boundingBox.min_corner().get<1>();
+    xMinBB = boundingBox.min_corner().get<0>();
+    yMinBB = boundingBox.min_corner().get<1>();
 
-    double xMaxBB = boundingBox.max_corner().get<0>();
-    double yMaxBB = boundingBox.max_corner().get<1>();
+    xMaxBB = boundingBox.max_corner().get<0>();
+    yMaxBB = boundingBox.max_corner().get<1>();
 
     if (isXSymm)
       xMin = xMinBB;

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1341,7 +1341,6 @@ void Foundation::createMeshData() {
       blocks.push_back(block);
 
       if (twoParameters) {
-        Block block;
         block.material = b.material;
         block.blockType = Block::SOLID;
         block.xMin = xRef1 - b.box.min_corner().get<0>();
@@ -1410,20 +1409,20 @@ void Foundation::createMeshData() {
   } else if (numberOfDimensions == 3 && !useSymmetry) {
 #if defined(KIVA_3D)
     // TODO 3D
-    Box boundingBox;
-    boost::geometry::envelope(polygon, boundingBox);
+    Box _boundingBox;
+    boost::geometry::envelope(polygon, _boundingBox);
 
-    xMinBB = boundingBox.min_corner().get<0>();
-    yMinBB = boundingBox.min_corner().get<1>();
+    double _xMinBB = _boundingBox.min_corner().get<0>();
+    double _yMinBB = _boundingBox.min_corner().get<1>();
 
-    xMaxBB = boundingBox.max_corner().get<0>();
-    yMaxBB = boundingBox.max_corner().get<1>();
+    double _xMaxBB = _boundingBox.max_corner().get<0>();
+    double _yMaxBB = _boundingBox.max_corner().get<1>();
 
-    xMin = xMinBB - farFieldWidth;
-    yMin = yMinBB - farFieldWidth;
+    xMin = _xMinBB - farFieldWidth;
+    yMin = _yMinBB - farFieldWidth;
 
-    xMax = xMaxBB + farFieldWidth;
-    yMax = yMaxBB + farFieldWidth;
+    xMax = _xMaxBB + farFieldWidth;
+    yMax = _yMaxBB + farFieldWidth;
 
     if (isGreaterThan(zMax, 0.0)) {
 
@@ -2032,27 +2031,27 @@ void Foundation::createMeshData() {
 
     nV = symmetricPoly.outer().size();
 
-    Box boundingBox;
-    boost::geometry::envelope(symmetricPoly, boundingBox);
+    Box _boundingBox;
+    boost::geometry::envelope(symmetricPoly, _boundingBox);
 
-    xMinBB = boundingBox.min_corner().get<0>();
-    yMinBB = boundingBox.min_corner().get<1>();
+    double _xMinBB = _boundingBox.min_corner().get<0>();
+    double _yMinBB = _boundingBox.min_corner().get<1>();
 
-    xMaxBB = boundingBox.max_corner().get<0>();
-    yMaxBB = boundingBox.max_corner().get<1>();
+    double _xMaxBB = _boundingBox.max_corner().get<0>();
+    double _yMaxBB = _boundingBox.max_corner().get<1>();
 
     if (isXSymm)
-      xMin = xMinBB;
+      xMin = _xMinBB;
     else
-      xMin = xMinBB - farFieldWidth;
+      xMin = _xMinBB - farFieldWidth;
 
     if (isYSymm)
-      yMin = yMinBB;
+      yMin = _yMinBB;
     else
-      yMin = yMinBB - farFieldWidth;
+      yMin = _yMinBB - farFieldWidth;
 
-    xMax = xMaxBB + farFieldWidth;
-    yMax = yMaxBB + farFieldWidth;
+    xMax = _xMaxBB + farFieldWidth;
+    yMax = _yMaxBB + farFieldWidth;
 
     Box domainBox(Point(xMin, yMin), Point(xMax, yMax));
 

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -8,12 +8,14 @@ namespace Kiva {
 
 static const double PI = 4.0 * atan(1.0);
 
-Material::Material() {}
+Material::Material() : conductivity{0}, density{0}, specificHeat{0} {}
 
 Material::Material(double k, double rho, double cp)
     : conductivity(k), density(rho), specificHeat(cp) {}
 
-InputBlock::InputBlock() : x(0.0), z(0.0), width(0.0), depth(0.0) {}
+InputBlock::InputBlock()
+    : x(0.0), z(0.0), width(0.0), depth(0.0),
+      box(Point(0, 0), Point(1, 1)) {}
 
 double Wall::totalWidth() {
   double width = 0.0;

--- a/src/libkiva/Foundation.hpp
+++ b/src/libkiva/Foundation.hpp
@@ -51,7 +51,7 @@ public:
   SurfaceProperties exterior;
 
   double heightAboveGrade; // [m]
-  double depthBelowSlab;   // [m]
+  double depthBelowSlab{}; // [m]
   std::vector<Layer> layers;
 
   double totalWidth();

--- a/src/libkiva/Ground.cpp
+++ b/src/libkiva/Ground.cpp
@@ -546,16 +546,16 @@ void Ground::setNewBoundaryGeometry() {
       vNext2 = v + 2;
 
     Point a = foundation.polygon.outer()[vPrev];
-    Point b = foundation.polygon.outer()[v];
+    Point m_b = foundation.polygon.outer()[v];
     Point c = foundation.polygon.outer()[vNext];
     Point d = foundation.polygon.outer()[vNext2];
 
     // Correct U-turns
     if (foundation.isExposedPerimeter[vPrev] && foundation.isExposedPerimeter[v] &&
         foundation.isExposedPerimeter[vNext]) {
-      if (isEqual(getAngle(a, b, c) + getAngle(b, c, d), PI)) {
-        double AB = getDistance(a, b);
-        double BC = getDistance(b, c);
+      if (isEqual(getAngle(a, m_b, c) + getAngle(m_b, c, d), PI)) {
+        double AB = getDistance(a, m_b);
+        double BC = getDistance(m_b, c);
         double CD = getDistance(c, d);
         double edgeDistance = BC;
         double reductionDistance = std::min(AB, CD);
@@ -565,9 +565,9 @@ void Ground::setNewBoundaryGeometry() {
     }
 
     if (foundation.isExposedPerimeter[vPrev] && foundation.isExposedPerimeter[v]) {
-      double alpha = getAngle(a, b, c);
-      double A = getDistance(a, b);
-      double B = getDistance(b, c);
+      double alpha = getAngle(a, m_b, c);
+      double A = getDistance(a, m_b);
+      double B = getDistance(m_b, c);
 
       if (sin(alpha) > 0) {
         double f = getBoundaryDistance(1 - sin(alpha / 2) / (1 + cos(alpha / 2))) / sin(alpha / 2);
@@ -588,7 +588,7 @@ void Ground::setNewBoundaryGeometry() {
     }
 
     if (!foundation.isExposedPerimeter[v]) {
-      interiorPerimeter += getDistance(b, c);
+      interiorPerimeter += getDistance(m_b, c);
     }
   }
 

--- a/src/libkiva/Ground.cpp
+++ b/src/libkiva/Ground.cpp
@@ -97,7 +97,7 @@ void Ground::calculateADEUpwardSweep() {
 
 void Ground::calculateADEDownwardSweep() {
   // Downward sweep (Solve V Matrix starting from I, K)
-  for (size_t index = num_cells - 1; /* i >= 0 && */ index < num_cells; index--) {
+  for (int index = static_cast<int>(num_cells) - 1; index >= 0; index--) {
     auto this_cell = domain.cell[index];
     this_cell->calcCellADEDown(timestep, foundation, bcs, V[index]);
   }
@@ -548,15 +548,15 @@ void Ground::setNewBoundaryGeometry() {
     Point a = foundation.polygon.outer()[vPrev];
     Point m_b = foundation.polygon.outer()[v];
     Point c = foundation.polygon.outer()[vNext];
-    Point d = foundation.polygon.outer()[vNext2];
+    Point m_d = foundation.polygon.outer()[vNext2];
 
     // Correct U-turns
     if (foundation.isExposedPerimeter[vPrev] && foundation.isExposedPerimeter[v] &&
         foundation.isExposedPerimeter[vNext]) {
-      if (isEqual(getAngle(a, m_b, c) + getAngle(m_b, c, d), PI)) {
+      if (isEqual(getAngle(a, m_b, c) + getAngle(m_b, c, m_d), PI)) {
         double AB = getDistance(a, m_b);
         double BC = getDistance(m_b, c);
-        double CD = getDistance(c, d);
+        double CD = getDistance(c, m_d);
         double edgeDistance = BC;
         double reductionDistance = std::min(AB, CD);
         double reductionValue = 1 - getBoundaryValue(edgeDistance);

--- a/src/libkiva/Mesher.cpp
+++ b/src/libkiva/Mesher.cpp
@@ -201,7 +201,7 @@ std::size_t Mesher::getNearestIndex(double position) {
           return i;
       }
     }
-    return -1;
+    return NULL;
   }
 }
 
@@ -216,7 +216,7 @@ std::size_t Mesher::getNextIndex(double position) {
           isLessThan(position, this->centers[i + 1]))
         return i + 1;
     }
-    return -1;
+    return NULL;
   }
 }
 
@@ -231,7 +231,7 @@ std::size_t Mesher::getPreviousIndex(double position) {
           isLessOrEqual(position, this->centers[i]))
         return i - 1;
     }
-    return -1;
+    return NULL;
   }
 }
 } // namespace Kiva

--- a/src/libkiva/Mesher.cpp
+++ b/src/libkiva/Mesher.cpp
@@ -201,7 +201,7 @@ std::size_t Mesher::getNearestIndex(double position) {
           return i;
       }
     }
-    return NULL;
+    return 0;
   }
 }
 
@@ -216,7 +216,7 @@ std::size_t Mesher::getNextIndex(double position) {
           isLessThan(position, this->centers[i + 1]))
         return i + 1;
     }
-    return NULL;
+    return 0;
   }
 }
 
@@ -231,7 +231,7 @@ std::size_t Mesher::getPreviousIndex(double position) {
           isLessOrEqual(position, this->centers[i]))
         return i - 1;
     }
-    return NULL;
+    return 0;
   }
 }
 } // namespace Kiva

--- a/src/libkiva/Mesher.cpp
+++ b/src/libkiva/Mesher.cpp
@@ -201,7 +201,7 @@ std::size_t Mesher::getNearestIndex(double position) {
           return i;
       }
     }
-    return 0;
+    showMessage(MSG_ERR, "Could not find the nearest Index.");
   }
 }
 
@@ -216,7 +216,7 @@ std::size_t Mesher::getNextIndex(double position) {
           isLessThan(position, this->centers[i + 1]))
         return i + 1;
     }
-    return 0;
+    showMessage(MSG_ERR, "Could not find the next Index.");
   }
 }
 
@@ -231,7 +231,7 @@ std::size_t Mesher::getPreviousIndex(double position) {
           isLessOrEqual(position, this->centers[i]))
         return i - 1;
     }
-    return 0;
+    showMessage(MSG_ERR, "Could not find the previous Index.");
   }
 }
 } // namespace Kiva

--- a/src/libkiva/Mesher.cpp
+++ b/src/libkiva/Mesher.cpp
@@ -28,7 +28,7 @@ Mesher::Mesher(MeshData &data) : data(data) {
     double max = data.points[i + 1];
     double length = max - min;
     double cellWidth;
-    int numCells;
+    int numCells{0};
 
     if (isEqual(length, 0.0)) {
       // Zero width cells (used for boundary conditions)
@@ -126,7 +126,7 @@ Mesher::Mesher(MeshData &data) : data(data) {
           } else {
             bool search = true;
             int N = 0;
-            double multiplier;
+            double multiplier{0};
 
             while (search) {
               multiplier = 0.0;

--- a/src/libkiva/Mesher.cpp
+++ b/src/libkiva/Mesher.cpp
@@ -202,6 +202,7 @@ std::size_t Mesher::getNearestIndex(double position) {
       }
     }
     showMessage(MSG_ERR, "Could not find the nearest Index.");
+    return 0;
   }
 }
 
@@ -217,6 +218,7 @@ std::size_t Mesher::getNextIndex(double position) {
         return i + 1;
     }
     showMessage(MSG_ERR, "Could not find the next Index.");
+    return 0;
   }
 }
 
@@ -232,6 +234,7 @@ std::size_t Mesher::getPreviousIndex(double position) {
         return i - 1;
     }
     showMessage(MSG_ERR, "Could not find the previous Index.");
+    return 0;
   }
 }
 } // namespace Kiva

--- a/src/libkiva/Mesher.hpp
+++ b/src/libkiva/Mesher.hpp
@@ -6,6 +6,7 @@
 
 #include "Functions.hpp"
 #include "libkiva_export.h"
+#include "Errors.hpp"
 #include <cmath>
 #include <math.h>
 #include <vector>

--- a/src/libkiva/Version.hpp.in
+++ b/src/libkiva/Version.hpp.in
@@ -6,9 +6,9 @@
 
 namespace Kiva {
 
-std::string getVersion() { return "@VERSION_NUMBER@"; };
+std::string getVersion() { return "@VERSION_NUMBER@"; }
 
-std::string getYear() { return "@YEAR@"; };
+std::string getYear() { return "@YEAR@"; }
 
 } // namespace Kiva
 


### PR DESCRIPTION
This pull request cleans all level 4 warnings and suppresses any third-party warnings that do not meet Kiva's new warning level. The suppression technique used in this PR is through CMake.