### PR TITLE
Increase CI coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,8 +29,8 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: 'clang14'
-            cxx: 'clang++14'
+            cc: 'clang'
+            cxx: 'clang++'
           - os: ubuntu-latest
             config: Debug
             static_lib: OFF

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,8 @@ jobs:
             static_lib: ON
             coverage: OFF
             gcc: 11
+            CC: gcc-11
+            CXX: g++-11
           - os: windows-latest
             config: Release
             static_lib: ON

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,15 +52,19 @@ jobs:
 
       - name: Install Linux Libraries
         if: matrix.os == 'ubuntu-latest'
-        env: 
-          CC: gcc-10
-          CXX: g++-10
         run: |
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
+        if: matrix.os == 'ubuntu-latest'
+        env: 
+            CC: gcc-10
+            CXX: g++-10
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+        if: matrix.os != 'ubuntu-latest'
+        run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,42 +14,42 @@ jobs:
       matrix:
         include:
           - os: ubuntu
-            os-ver: "22.04"
+            os_ver: "22.04"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: gcc-11
             cxx: g++-11
           - os: ubuntu
-            os-ver: "20.04"
+            os_ver: "20.04"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
           - os: windows
-            os-ver: "2022"
+            os_ver: "2022"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: cl
             cxx: cl
           - os: macos
-            os-ver: "12"
+            os_ver: "12"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: clang
             cxx: clang++
           - os: macos
-            os-ver: "11"
+            os_ver: "11"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: clang
             cxx: clang++
           - os: ubuntu
-            os-ver: "20.04"
+            os_ver: "20.04"
             config: Debug
             static_lib: OFF
             coverage: ON

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,13 +54,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
+
+      - name: Use GCC-11
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
 
       - name: Configure CMake
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          CC: gcc-10
-          CXX: g++-10
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,8 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
+            gcc: 10
+            g++: 10
           - os: windows-latest
             config: Release
             static_lib: ON
@@ -29,6 +31,8 @@ jobs:
             config: Debug
             static_lib: OFF
             coverage: ON
+            CC: gcc-10
+            CXX: g++-10
     defaults:
       run:
         shell: bash
@@ -54,11 +58,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
-
-      - name: Use GCC-11
-        if: matrix.os == 'ubuntu-latest'
-        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,25 +13,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: "gcc-11"
+            cxx: "g++-11"
+          - os: ubuntu-20.04
             config: Release
             static_lib: ON
             coverage: OFF
             cc: "gcc-10"
             cxx: "g++-10"
-          - os: windows-latest
+          - os: windows-2022
             config: Release
             static_lib: ON
             coverage: OFF
             cc: "cl"
             cxx: "cl"
-          - os: macos-latest
+          - os: macos-12
             config: Release
             static_lib: ON
             coverage: OFF
             cc: 'clang'
             cxx: 'clang++'
-          - os: ubuntu-latest
+          - os: macos-11
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: 'clang'
+            cxx: 'clang++'
+          - os: ubuntu-20.04
             config: Debug
             static_lib: OFF
             coverage: ON

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,7 @@ jobs:
 
       - name: Use GCC-11
         if: matrix.os == 'ubuntu-latest'
-        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GIHUB_ENV
-        #env:
-        #  CC: gcc-11
-        #  CXX: g++-11
+        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,9 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            gcc: 11
-            CC: gcc-11
-            CXX: g++-11
+            env:
+              CC: gcc-11
+              CXX: g++-11
           - os: windows-latest
             config: Release
             static_lib: ON

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,6 +52,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    env: 
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -77,9 +80,6 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
-        env: 
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,10 @@ jobs:
 
       - name: Use GCC-11
         if: matrix.os == 'ubuntu-latest'
-        run: |
-        env:
-          CC: gcc-11
-          CXX: g++-11
+        run: echo "CC=gcc-11" >> $GITHUB_ENV || echo "CXX=g++-11" >> $GIHUB_ENV
+        #env:
+        #  CC: gcc-11
+        #  CXX: g++-11
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,6 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            env:
-              CC: gcc-11
-              CXX: g++-11
           - os: windows-latest
             config: Release
             static_lib: ON
@@ -60,6 +57,10 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CC: gcc-11
+          CXX: g++-11
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,18 +17,26 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
+            cc: "gcc-10"
+            cxx: "g++-10"
           - os: windows-latest
             config: Release
             static_lib: ON
             coverage: OFF
+            cc: "cl"
+            cxx: "cl"
           - os: macos-latest
             config: Release
             static_lib: ON
             coverage: OFF
+            cc: "clang"
+            cxx: "clang++"
           - os: ubuntu-latest
             config: Debug
             static_lib: OFF
             coverage: ON
+            cc: "gcc-10"
+            cxx: "g++-10"
     defaults:
       run:
         shell: bash
@@ -57,14 +65,7 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
-        if: matrix.os == 'ubuntu-latest'
-        env: 
-            CC: gcc-10
-            CXX: g++-10
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
-        if: matrix.os != 'ubuntu-latest'
-        run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
-
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,8 +29,8 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: '$(brew --prefix llvm@14)/bin/clang'
-            cxx: '$(brew --prefix llvm@14)/bin/clang++'
+            cc: 'clang14'
+            cxx: 'clang++14'
           - os: ubuntu-latest
             config: Debug
             static_lib: OFF

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,8 +29,8 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: "clang"
-            cxx: "clang++"
+            cc: '$(brew --prefix llvm@14)/bin/clang'
+            cxx: '$(brew --prefix llvm@14)/bin/clang++'
           - os: ubuntu-latest
             config: Debug
             static_lib: OFF

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,6 +65,9 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
+        env: 
+            CC: ${{ matrix.cc }}
+            CXX: ${{ matrix.cxx }}
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Use GCC-11
         if: matrix.os == 'ubuntu-latest'
-        run: echo "CC=gcc-11" >> $GITHUB_ENV || echo "CXX=g++-11" >> $GIHUB_ENV
+        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GIHUB_ENV
         #env:
         #  CC: gcc-11
         #  CXX: g++-11

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,7 +62,6 @@ jobs:
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
-        if: matrix.os == 'ubuntu-latest'
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,6 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            env:
-              gcc: 10
-              g++: 10
           - os: windows-latest
             config: Release
             static_lib: ON
@@ -32,9 +29,6 @@ jobs:
             config: Debug
             static_lib: OFF
             coverage: ON
-            env:
-              CC: gcc-10
-              CXX: g++-10
     defaults:
       run:
         shell: bash
@@ -61,6 +55,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
+
+      - name: Set-up GCC version
+        if: matrix.os == 'ubuntu-latest'
+        env: 
+          CC: gcc-10
+          CXX: g++-10
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Install Linux Libraries
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,14 +54,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
         if: matrix.os == 'ubuntu-latest'
-        env:
-          CC:   gcc-11
-          CXX:  g++-11
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,6 +57,7 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
 
       - name: Use GCC-11
+        if: matrix.os == 'ubuntu-latest'
         run: |
         env:
           CC: gcc-11

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,12 +50,6 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}/build
 
-      - name: Use GCC-11
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          CC:   gcc-11
-          CXX:  g++-11
-
       - name: Install Linux Libraries
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -64,6 +58,10 @@ jobs:
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CC:   gcc-11
+          CXX:  g++-11
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,15 +52,12 @@ jobs:
 
       - name: Install Linux Libraries
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
-
-      - name: Set-up GCC version
-        if: matrix.os == 'ubuntu-latest'
         env: 
           CC: gcc-10
           CXX: g++-10
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,8 +17,9 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
-            gcc: 10
-            g++: 10
+            env:
+              gcc: 10
+              g++: 10
           - os: windows-latest
             config: Release
             static_lib: ON
@@ -31,8 +32,9 @@ jobs:
             config: Debug
             static_lib: OFF
             coverage: ON
-            CC: gcc-10
-            CXX: g++-10
+            env:
+              CC: gcc-10
+              CXX: g++-10
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,7 @@ jobs:
             config: Release
             static_lib: ON
             coverage: OFF
+            gcc: 11
           - os: windows-latest
             config: Release
             static_lib: ON
@@ -54,11 +55,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
-
-      - name: Use GCC-11
-        if: matrix.os == 'ubuntu-latest'
-        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}/build
 
+      - name: Use GCC-11
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CC:   gcc-11
+          CXX:  g++-11
+
       - name: Install Linux Libraries
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Configure CMake
         if: matrix.os == 'ubuntu-latest'
         env:
-          CC: gcc-11
-          CXX: g++-11
+          CC: gcc-10
+          CXX: g++-10
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,6 +56,12 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
 
+      - name: Use GCC-11
+        run: |
+        env:
+          CC: gcc-11
+          CXX: g++-11
+
       - name: Configure CMake
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,49 +13,55 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu
+            os-ver: "22.04"
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: "gcc-11"
-            cxx: "g++-11"
-          - os: ubuntu-20.04
+            cc: gcc-11
+            cxx: g++-11
+          - os: ubuntu
+            os-ver: "20.04"
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: "gcc-10"
-            cxx: "g++-10"
-          - os: windows-2022
+            cc: gcc-10
+            cxx: g++-10
+          - os: windows
+            os-ver: "2022"
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: "cl"
-            cxx: "cl"
-          - os: macos-12
+            cc: cl
+            cxx: cl
+          - os: macos
+            os-ver: "12"
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: 'clang'
-            cxx: 'clang++'
-          - os: macos-11
+            cc: clang
+            cxx: clang++
+          - os: macos
+            os-ver: "11"
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: 'clang'
-            cxx: 'clang++'
-          - os: ubuntu-20.04
+            cc: clang
+            cxx: clang++
+          - os: ubuntu
+            os-ver: "20.04"
             config: Debug
             static_lib: OFF
             coverage: ON
-            cc: "gcc-10"
-            cxx: "g++-10"
+            cc: gcc-10
+            cxx: g++-10
     defaults:
       run:
         shell: bash
     env: 
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -74,7 +80,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Install Linux Libraries
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu'
         run: |
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Configure CMake
         env: 
-            CC: ${{ matrix.cc }}
-            CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            cc: "gcc-10"
+            cxx: "g++-10"
           - os: windows-latest
+            cc: "cl"
+            cxx: "cl"
           - os: macos-latest
+            cc: "clang"
+            cxx: "clang++"
     defaults:
       run:
         shell: bash
@@ -40,13 +46,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
-
-      - name: Use GCC-11
-        if: matrix.os == 'ubuntu-latest'
-        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev 
 
       - name: Configure CMake
+        cc: ${{ matrix.cc }}
+        cxx: ${{ matrix.cxx }}
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
             cc: "cl"
             cxx: "cl"
           - os: macos-latest
-            cc: "clang"
-            cxx: "clang++"
+            cc: '$(brew --prefix llvm@14)/bin/clang'
+            cxx: '$(brew --prefix llvm@14)/bin/clang++'
     defaults:
       run:
         shell: bash
@@ -46,7 +46,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev 
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
         cc: ${{ matrix.cc }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
             cc: "cl"
             cxx: "cl"
           - os: macos-latest
-            cc: '$(brew --prefix llvm@14)/bin/clang'
-            cxx: '$(brew --prefix llvm@14)/bin/clang++'
+            cc: 'clang'
+            cxx: 'clang++'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -49,8 +52,6 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
-        cc: ${{ matrix.cc }}
-        cxx: ${{ matrix.cxx }}
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu
-            os-ver: "20.04"
+            os_ver: "20.04"
             cc: gcc-10
             cxx: g++-10
           - os: windows
-            os-ver: "2022"
+            os_ver: "2022"
             cc: cl
             cxx: cl
           - os: macos
-            os-ver: "11"
+            os_ver: "11"
             cc: clang
             cxx: clang++
     defaults:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,22 +12,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            cc: "gcc-10"
-            cxx: "g++-10"
-          - os: windows-2022
-            cc: "cl"
-            cxx: "cl"
-          - os: macos-11
-            cc: 'clang'
-            cxx: 'clang++'
+          - os: ubuntu
+            os-ver: "20.04"
+            cc: gcc-10
+            cxx: g++-10
+          - os: windows
+            os-ver: "2022"
+            cc: cl
+            cxx: cl
+          - os: macos
+            os-ver: "11"
+            cc: clang
+            cxx: clang++
     defaults:
       run:
         shell: bash
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +49,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Install Linux Libraries
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu'
         run: |
           sudo apt-get update
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             cc: "gcc-10"
             cxx: "g++-10"
-          - os: windows-latest
+          - os: windows-2022
             cc: "cl"
             cxx: "cl"
-          - os: macos-latest
+          - os: macos-11
             cc: 'clang'
             cxx: 'clang++'
     defaults:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev gcc-11 g++-11
+
+      - name: Use GCC-11
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
 
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -16,11 +16,6 @@ target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 
-set(kiva_suppress_warnings Main.cpp
-                           Input.cpp
-                           InputParser.cpp
-                           Simulator.cpp)
-
 target_compile_options(kiva PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
## Description

Major changes:
- Adds more specificity to the os version and the compiler version
- Adds Ubuntu-22.04 and macOS-12 to the CI matrix
- Adds `gcc-10` and `gcc-11` coverage

Minor changes:
- Remove kiva_suppress_warnings