### PR TITLE
Add KIVA_WERROR option to interpret compiler warnings as errors

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
-        run: cmake -S . -B build -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+        run: cmake -S . -B build -DKIVA_WERROR="ON" -DKIVA_COVERAGE="${{ matrix.coverage }}" -DKIVA_STATIC_LIB="${{ matrix.static_lib }}" -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
 
       - name: Setup tooling
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DKIVA_WERROR="ON"
 
       - name: Build
         run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(ENABLE_OPENMP "Use OpenMP" OFF)
 option( KIVA_GROUND_PLOT "Build ground plotting library" ON )
 mark_as_advanced(FORCE BUILD_GROUND_PLOT)
 option( KIVA_TESTING "Build tests" ON )
+option( KIVA_WERROR "Turn on warnings into error" ON )
 
 find_package(Git QUIET)
 
@@ -20,6 +21,8 @@ if (KIVA_TESTING)
     find_package(codecov)
   endif()
 endif()
+
+include(compiler-flags)
 
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY "${kiva_BINARY_DIR}" )
 set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${kiva_BINARY_DIR}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ENABLE_OPENMP "Use OpenMP" OFF)
 option( KIVA_GROUND_PLOT "Build ground plotting library" ON )
 mark_as_advanced(FORCE BUILD_GROUND_PLOT)
 option( KIVA_TESTING "Build tests" ON )
-option( KIVA_WERROR "Turn on warnings into error" ON )
+option( KIVA_WERROR "Turn on warnings into error" OFF )
 
 find_package(Git QUIET)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pre-requisites:
 Building Kiva from source
 -------------------------
 
-1. Clone the git repository, or download and extract the source code (`tar.gz` or `zip`).
+1. Clone the git repository.
 2. Make a directory called `build` inside the top level of your source.
 3. Open a console in the `build` directory.
 4. Type `cmake ..`.

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -15,9 +15,9 @@ add_library(kiva_common_interface INTERFACE)
 
 target_compile_options(kiva_common_interface INTERFACE
 $<$<CXX_COMPILER_ID:MSVC>:
-  /W4
+  /W4 # Warning level (default is W3)
   $<$<BOOL:${KIVA_WERROR}>:
-    /WX
+    /WX # Turn warnings into errors
   >
 >
 $<$<CXX_COMPILER_ID:GNU>:
@@ -25,7 +25,7 @@ $<$<CXX_COMPILER_ID:GNU>:
   -Wextra 
   -Wpedantic 
   $<$<BOOL:${KIVA_WERROR}>:
-    -Werror
+    -Werror # Turn warnings into errors
   >
 >
 
@@ -34,7 +34,7 @@ $<$<CXX_COMPILER_ID:Clang>:
   -Wextra 
   -Wpedantic
   $<$<BOOL:${KIVA_WERROR}>:
-    -Werror
+    -Werror # Turn warnings into errors
   >
 >
 )

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,0 +1,40 @@
+# Empty default flags
+# set(CMAKE_C_FLAGS "")
+# set(CMAKE_CXX_FLAGS "")
+# set(CMAKE_CXX_FLAGS_RELEASE "")
+# set(CMAKE_CXX_FLAGS_DEBUG "")
+# set(CMAKE_EXE_LINKER_FLAGS "")
+# set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
+# set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
+
+add_library(kiva_common_interface INTERFACE)
+
+  #================#
+  # Compiler flags #
+  #================#
+
+target_compile_options(kiva_common_interface INTERFACE
+$<$<CXX_COMPILER_ID:MSVC>:
+  /W4
+  $<$<BOOL:${KIVA_WERROR}>:
+    /WX
+  >
+>
+$<$<CXX_COMPILER_ID:GNU>:
+  -Wall 
+  -Wextra 
+  -Wpedantic 
+  $<$<BOOL:${KIVA_WERROR}>:
+    -Werror
+  >
+>
+
+$<$<CXX_COMPILER_ID:Clang>:
+  -Wall 
+  -Wextra 
+  -Wpedantic
+  $<$<BOOL:${KIVA_WERROR}>:
+    -Werror
+  >
+>
+)

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -11,7 +11,7 @@ $<$<CXX_COMPILER_ID:MSVC>:
     /WX # Turn warnings into errors
   >
 >
-$<$<CXX_COMPILER_ID:GNU>:
+$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
   -Wall 
   -Wextra 
   -Wpedantic 
@@ -20,12 +20,4 @@ $<$<CXX_COMPILER_ID:GNU>:
   >
 >
 
-$<$<CXX_COMPILER_ID:Clang>:
-  -Wall 
-  -Wextra 
-  -Wpedantic
-  $<$<BOOL:${KIVA_WERROR}>:
-    -Werror # Turn warnings into errors
-  >
->
 )

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,12 +1,3 @@
-# Empty default flags
-# set(CMAKE_C_FLAGS "")
-# set(CMAKE_CXX_FLAGS "")
-# set(CMAKE_CXX_FLAGS_RELEASE "")
-# set(CMAKE_CXX_FLAGS_DEBUG "")
-# set(CMAKE_EXE_LINKER_FLAGS "")
-# set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
-# set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
-
 add_library(kiva_common_interface INTERFACE)
 
   #================#

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
 
-target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp kiva_common_interface)
+target_link_libraries(kiva PRIVATE libkiva groundplot boost_program_options yaml-cpp kiva_common_interface)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
 
-target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp)
+target_link_libraries(kiva libkiva groundplot boost_program_options yaml-cpp kiva_common_interface)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 
@@ -20,12 +20,6 @@ set(kiva_suppress_warnings Main.cpp
                            Input.cpp
                            InputParser.cpp
                            Simulator.cpp)
-
-target_compile_options(kiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-  -Wall -Wextra -Wpedantic -Werror>
-)
 
 if (KIVA_COVERAGE)
   add_coverage(kiva)

--- a/src/kiva/CMakeLists.txt
+++ b/src/kiva/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_INSTALL_RPATH "@executable_path")
 
 add_executable(kiva ${kiva_src})
 
-target_link_libraries(kiva PRIVATE libkiva groundplot boost_program_options yaml-cpp kiva_common_interface)
+target_link_libraries(kiva PRIVATE groundplot boost_program_options yaml-cpp kiva_common_interface)
 
 target_include_directories(kiva PRIVATE "${groundplot_SOURCE_DIR}")
 

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -5,15 +5,9 @@ set(groundplot_src  GroundPlot.cpp
 
 add_library(groundplot STATIC ${groundplot_src})
 
-target_link_libraries(groundplot fmt mgl-static libkiva)
+target_link_libraries(groundplot fmt mgl-static libkiva kiva_common_interface)
 
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
-
-target_compile_options(groundplot PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-  -Wall -Wextra -Wpedantic -Werror>
-  )
 
 if (KIVA_COVERAGE)
   add_coverage(groundplot)

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -5,7 +5,7 @@ set(groundplot_src  GroundPlot.cpp
 
 add_library(groundplot STATIC ${groundplot_src})
 
-target_link_libraries(groundplot fmt mgl-static libkiva kiva_common_interface)
+target_link_libraries(groundplot PRIVATE fmt mgl-static libkiva kiva_common_interface)
 
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -5,7 +5,7 @@ set(groundplot_src  GroundPlot.cpp
 
 add_library(groundplot STATIC ${groundplot_src})
 
-target_link_libraries(groundplot PUBLIC fmt mgl-static libkiva kiva_common_interface)
+target_link_libraries(groundplot PUBLIC fmt mgl-static libkiva PRIVATE kiva_common_interface)
 
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 

--- a/src/libgroundplot/CMakeLists.txt
+++ b/src/libgroundplot/CMakeLists.txt
@@ -5,7 +5,7 @@ set(groundplot_src  GroundPlot.cpp
 
 add_library(groundplot STATIC ${groundplot_src})
 
-target_link_libraries(groundplot PRIVATE fmt mgl-static libkiva kiva_common_interface)
+target_link_libraries(groundplot PUBLIC fmt mgl-static libkiva kiva_common_interface)
 
 target_include_directories(groundplot PUBLIC "${MathGL2_SOURCE_DIR}/include" "${MathGL2_BINARY_DIR}/include")
 

--- a/src/libkiva/CMakeLists.txt
+++ b/src/libkiva/CMakeLists.txt
@@ -179,11 +179,7 @@ target_include_directories(libkiva PUBLIC
   "${BOOST_SOURCE_DIR}"
   "${kiva_SOURCE_DIR}/vendor/eigen")
 
-target_compile_options(libkiva PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-  -Wall -Wextra -Wpedantic -Werror>
-)
+target_link_libraries(libkiva PRIVATE kiva_common_interface)
 target_compile_features(libkiva PUBLIC cxx_std_17) # Should be PRIVATE once boost is cleaned out of public API
 
 include(GenerateExportHeader)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -6,7 +6,7 @@ set(kiva_test_src
 
 add_executable(kiva_tests ${kiva_test_src})
 
-target_link_libraries(kiva_tests gtest libkiva)
+target_link_libraries(kiva_tests PRIVATE gtest libkiva kiva_common_interface)
 
 add_test(NAME unit.GC10aFixture.calculateADI COMMAND $<TARGET_FILE:kiva_tests> "--gtest_filter=GC10aFixture.calculateADI")
 add_test(NAME unit.GC10aFixture.calculateImplicit COMMAND $<TARGET_FILE:kiva_tests> "--gtest_filter=GC10aFixture.calculateImplicit")


### PR DESCRIPTION
## Description

The goal is to have the option to turn warnings into errors by 

### Major changes:

- Add compiler-flag.cmake and an interface library to distribute the compiler flags
- Add the option to turn off and on Werror (/WX for windows).