### PR TITLE
Fix timestep regression in executable

### DIFF
--- a/src/kiva/Simulator.cpp
+++ b/src/kiva/Simulator.cpp
@@ -129,7 +129,7 @@ void Simulator::initializeConditions() {
 
       for (boost::posix_time::ptime t = tWarmupStart; t <= tWarmupEnd; t += simulationTimestep) {
         updateBoundaryConditions(t);
-        ground.calculate(bcs, static_cast<double>(accelTimestep.total_seconds()));
+        ground.calculate(bcs, static_cast<double>(simulationTimestep.total_seconds()));
         printStatus(t);
       }
     }

--- a/src/libkiva/Domain.cpp
+++ b/src/libkiva/Domain.cpp
@@ -365,8 +365,9 @@ void Domain::printCellTypes() {
 
   output << "\n";
 
-  for (std::size_t k = dim_lengths[2] - 1; /* k >= 0 && */ k < dim_lengths[2]; k--) {
+  for (std::size_t n = dim_lengths[2]; n > 0; n--) {
 
+    std::size_t k = n - 1;
     output << k;
 
     for (std::size_t i = 0; i < dim_lengths[0]; i++) {

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1330,12 +1330,13 @@ void Foundation::createMeshData() {
         double xPosition = xRef2;
 
         // Foundation Wall
-        for (size_t n = wall.layers.size() - 1; n-->0; ) {
+        for (size_t n = wall.layers.size(); n > 0; n--) {
+          size_t index = n - 1;
           Block block;
-          block.material = wall.layers[n].material;
+          block.material = wall.layers[index].material;
           block.blockType = Block::SOLID;
           block.xMin = xPosition;
-          block.xMax = xPosition + wall.layers[n].thickness;
+          block.xMax = xPosition + wall.layers[index].thickness;
           block.yMin = 0.0;
           block.yMax = 1.0;
           block.setSquarePolygon();
@@ -1350,11 +1351,12 @@ void Foundation::createMeshData() {
         double xPosition = xRef1;
 
         // Foundation Wall
-        for (size_t n = wall.layers.size() - 1; n--> 0; ) {
+        for (size_t n = wall.layers.size(); n > 0; n--) {
+          size_t index = n - 1;
           Block block;
-          block.material = wall.layers[n].material;
+          block.material = wall.layers[index].material;
           block.blockType = Block::SOLID;
-          block.xMin = xPosition - wall.layers[n].thickness;
+          block.xMin = xPosition - wall.layers[index].thickness;
           block.xMax = xPosition;
           block.yMin = 0.0;
           block.yMax = 1.0;
@@ -1856,9 +1858,10 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (size_t n = wall.layers.size() - 1; n--> 0; ) {
+      for (size_t n = wall.layers.size(); n > 0; n--) {
+        size_t index = n - 1;
         Polygon poly;
-        poly = offset(polygon, xyPosition + wall.layers[n].thickness);
+        poly = offset(polygon, xyPosition + wall.layers[index].thickness);
 
         Polygon temp;
         temp = offset(polygon, xyPosition);
@@ -1869,12 +1872,12 @@ void Foundation::createMeshData() {
         poly.inners().push_back(ring);
 
         Block block;
-        block.material = wall.layers[n].material;
+        block.material = wall.layers[index].material;
         block.blockType = Block::SOLID;
         block.polygon = poly;
         block.zMin = zWall;
         block.zMax = zMax;
-        xyPosition += wall.layers[n].thickness;
+        xyPosition += wall.layers[index].thickness;
         blocks.push_back(block);
       }
     }
@@ -2426,9 +2429,10 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (size_t n = wall.layers.size() - 1; n--> 0; ) {
+      for (size_t n = wall.layers.size(); n > 0; n--) {
+        size_t index = n - 1;
         Polygon tempPoly;
-        tempPoly = offset(polygon, xyPosition + wall.layers[n].thickness);
+        tempPoly = offset(polygon, xyPosition + wall.layers[index].thickness);
 
         Polygon temp;
         temp = offset(polygon, xyPosition);
@@ -2442,12 +2446,12 @@ void Foundation::createMeshData() {
         boost::geometry::intersection(domainBox, tempPoly, poly);
 
         Block block;
-        block.material = wall.layers[n].material;
+        block.material = wall.layers[index].material;
         block.blockType = Block::SOLID;
         block.polygon = poly[0];
         block.zMin = zWall;
         block.zMax = zMax;
-        xyPosition += wall.layers[n].thickness;
+        xyPosition += wall.layers[index].thickness;
         blocks.push_back(block);
       }
     }

--- a/src/libkiva/Foundation.cpp
+++ b/src/libkiva/Foundation.cpp
@@ -1330,7 +1330,7 @@ void Foundation::createMeshData() {
         double xPosition = xRef2;
 
         // Foundation Wall
-        for (int n = static_cast<int>(wall.layers.size()) - 1; n >= 0; n--) {
+        for (size_t n = wall.layers.size() - 1; n-->0; ) {
           Block block;
           block.material = wall.layers[n].material;
           block.blockType = Block::SOLID;
@@ -1350,7 +1350,7 @@ void Foundation::createMeshData() {
         double xPosition = xRef1;
 
         // Foundation Wall
-        for (int n = static_cast<int>(wall.layers.size()) - 1; n >= 0; n--) {
+        for (size_t n = wall.layers.size() - 1; n--> 0; ) {
           Block block;
           block.material = wall.layers[n].material;
           block.blockType = Block::SOLID;
@@ -1856,7 +1856,7 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (int n = static_cast<int>(wall.layers.size() - 1); n >= 0; n--) {
+      for (size_t n = wall.layers.size() - 1; n--> 0; ) {
         Polygon poly;
         poly = offset(polygon, xyPosition + wall.layers[n].thickness);
 
@@ -2426,7 +2426,7 @@ void Foundation::createMeshData() {
       double xyPosition = 0.0;
 
       // Foundation Wall
-      for (int n = static_cast<int>(wall.layers.size() - 1); n >= 0; n--) {
+      for (size_t n = wall.layers.size() - 1; n--> 0; ) {
         Polygon tempPoly;
         tempPoly = offset(polygon, xyPosition + wall.layers[n].thickness);
 

--- a/src/libkiva/Functions.cpp
+++ b/src/libkiva/Functions.cpp
@@ -50,6 +50,7 @@ bool isEven(int N) { return (N % 2 == 0); }
 void solveTDM(const std::vector<double> &a1, const std::vector<double> &a2, std::vector<double> &a3,
               std::vector<double> &b, std::vector<double> &x) {
   std::size_t N = b.size();
+  std::size_t i_max = N - 1;
   std::size_t i;
 
   double const *a1_(&a1[0]);
@@ -65,8 +66,10 @@ void solveTDM(const std::vector<double> &a1, const std::vector<double> &a2, std:
     a3_[i] /= a2_[i] - a1_[i] * a3_[i - 1];
     b_[i] = (b_[i] - a1_[i] * b_[i - 1]) / (a2_[i] - a1_[i] * a3_[i - 1]);
   }
-  x_[N - 1] = b_[N - 1];
-  for (i = N - 2; /* i >= 0 && */ i < N; --i) {
+  x_[i_max] = b_[i_max];
+  // Exploit post-decrement for efficiency:
+  // First loop will be i = (i_max - 1) and last loop will be i = 0
+  for (i = i_max; i-- > 0;) {
     x_[i] = b_[i] - a3_[i] * x_[i + 1];
   }
 }

--- a/src/libkiva/Ground.cpp
+++ b/src/libkiva/Ground.cpp
@@ -103,14 +103,15 @@ void Ground::calculateADEUpwardSweep() {
 
 void Ground::calculateADEDownwardSweep() {
   // Downward sweep (Solve V Matrix starting from I, K)
-  for (int index = static_cast<int>(num_cells) - 1; index >= 0; index--) {
+  for (std::size_t n = num_cells; n > 0; n--) {
+    std::size_t index = n - 1;
     auto this_cell = domain.cell[index];
     this_cell->calcCellADEDown(timestep, foundation, bcs, V[index]);
   }
 }
 
 void Ground::calculateExplicit() {
-  for (size_t index = 0; index < num_cells; index++) {
+  for (std::size_t index = 0; index < num_cells; index++) {
     auto this_cell = domain.cell[index];
     TNew[index] = this_cell->calcCellExplicit(timestep, foundation, bcs);
   }
@@ -782,8 +783,9 @@ void Ground::writeCSV(std::string path) {
 
   output << "\n";
 
-  for (std::size_t k = nZ - 1; k < nZ /*k >= 0*/; k--) {
+  for (std::size_t n = nZ; n > 0; n--) {
 
+    std::size_t k = n - 1;
     output << k << ", " << domain.mesh[2].centers[k];
 
     for (std::size_t i = 0; i < nX; i++) {


### PR DESCRIPTION
# Fixes 

- Change `accelTimestep` back to `simulationTimestep`, this was the source of changes in the regression test.
- Fix count down for size_t variables.

# Test
- Comparing the `integration.BESTTEST.GC40b` test with same test from [this commit](https://github.com/bigladder/kiva/commit/2e4b30abcd4d5266a1e851064702832a2cd0fb8c) yield similar results with only changes in the 10^-9 decimal place or lower.