### PR TITLE
performance-for-range-copy

### DIFF
--- a/src/kiva/Input.cpp
+++ b/src/kiva/Input.cpp
@@ -71,8 +71,8 @@ OutputVariable::OutputVariable(int varID) {
 }
 
 void OutputReport::setOutputMap() {
-  for (auto outVar : *this) {
-    for (auto s : outVar.surfaces) {
+  for (const auto &outVar : *this) {
+    for (const auto &s : outVar.surfaces) {
       if (std::find(outputMap.begin(), outputMap.end(), s) ==
           outputMap.end()) { // If surface isn't in map create it and add to the list of outputs
         outputMap.push_back(s);

--- a/src/kiva/Simulator.cpp
+++ b/src/kiva/Simulator.cpp
@@ -364,7 +364,7 @@ std::string Simulator::printOutputHeaders() {
 std::string Simulator::printOutputLine() {
   std::string outputLine = "";
 
-  for (auto out : input.output.outputReport) {
+  for (const auto &out : input.output.outputReport) {
 
     double totalValue = 0.0;
     double totalVA = 0.0;

--- a/src/libkiva/Cell.cpp
+++ b/src/libkiva/Cell.cpp
@@ -112,7 +112,7 @@ void Cell::setZeroThicknessCellProperties(std::vector<std::shared_ptr<Cell>> poi
   std::vector<double> capacities;
   std::vector<double> weightedConductivity;
 
-  for (auto p_cell : pointSet) {
+  for (const auto &p_cell : pointSet) {
     // Do not add air cell properties into the weighted average
     if (p_cell->cellType != CellType::INTERIOR_AIR && p_cell->cellType != CellType::EXTERIOR_AIR) {
       double vol = p_cell->volume;

--- a/src/libkiva/Domain.cpp
+++ b/src/libkiva/Domain.cpp
@@ -178,7 +178,7 @@ void Domain::setDomain(Foundation &foundation) {
 
   // Set effective properties of zero-thickness cells
   // based on other cells
-  for (auto this_cell : cell) {
+  for (const auto &this_cell : cell) {
     std::size_t index = this_cell->index;
     std::tie(i, j, k) = getCoordinates(index);
 
@@ -215,7 +215,7 @@ void Domain::setDomain(Foundation &foundation) {
   }
 
   // Calculate matrix coefficients
-  for (auto this_cell : cell) {
+  for (const auto &this_cell : cell) {
     // PDE Coefficients
     this_cell->setComputeDims(dims);
     this_cell->setDistances(dxp_vector[this_cell->coords[0]], dxm_vector[this_cell->coords[0]],

--- a/src/libkiva/Ground.cpp
+++ b/src/libkiva/Ground.cpp
@@ -304,7 +304,7 @@ double Ground::getSurfaceArea(Surface::SurfaceType surfaceType) {
   double totalArea = 0;
 
   // Find surface(s)
-  for (auto surface : foundation.surfaces) {
+  for (const auto &surface : foundation.surfaces) {
     if (surface.type == surfaceType) {
       totalArea += surface.area;
     }
@@ -746,7 +746,7 @@ void Ground::setBoundaryConditions() {
 }
 
 void Ground::link_cells_to_temp() {
-  for (auto this_cell : domain.cell) {
+  for (const auto &this_cell : domain.cell) {
     this_cell->told_ptr = &TOld[this_cell->index];
   }
 }


### PR DESCRIPTION
Noticed while running this clang-tidy check on E+